### PR TITLE
Make GitHub not detect *.fs as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.fs linguist-language=Text


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub not to detect your `.fs` files as Forth.

Thanks!